### PR TITLE
Note that getUser already performs the OAuth step

### DIFF
--- a/samples.md
+++ b/samples.md
@@ -202,6 +202,10 @@ client.getAllUsers({
 });
 ```
 #### Get User
+
+Note that there is no need to authenticate the user through OAuth after you get the user. This 
+library does that for you.
+
 If using a static fingerprint across platform:
 ```
 client.getUser('<USER_ID>')


### PR DESCRIPTION
We ran into a production issue involving an invalid refresh token because we always tried to OAuth after calling `getUser`. 

Noting that we don't need to in the documentation will decrease the chance that someone else will do the same thing.