### PR TITLE
Add support for query filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsenode",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Node.js Library for SynapseFI API v3.1 Rest",
   "main": "dist/index.js",
   "files": [

--- a/samples.md
+++ b/samples.md
@@ -225,7 +225,8 @@ OR to pass in optional query parameters:
 ```javascript
 client.getPlatformTransactions({
   page: 2,
-  per_page: 10
+  per_page: 10,
+  filter: '{"supp_id": "supp_1234"}'
 })
 .then(({data}) => console.log('DATA\n', data))
 .catch(error => console.log(error));

--- a/samples.md
+++ b/samples.md
@@ -241,7 +241,8 @@ OR to pass in optional query parameters:
 ```javascript
 client.getPlatformNodes({
   page: 2,
-  per_page: 10
+  per_page: 10,
+  filter: '{"id": "12345"}'
 })
 .then(({data}) => console.log('DATA\n', data))
 .catch(error => console.log(error));
@@ -536,7 +537,8 @@ OR to pass in optional query parameters:
 ```javascript
 user.getUserTransactions({
   page: 2,
-  per_page: 10
+  per_page: 10,
+  filter: '{"id": "1245"}'
 })
 .then(({data}) => console.log('DATA\n', data))
 .catch(error => console.log(error));
@@ -740,7 +742,8 @@ OR to pass in optional query parameters:
 ```javascript
 user.getAllNodeTransactions('<NODE_ID>', {
   page: 2,
-  per_page: 5
+  per_page: 5,
+  filter: '{"id": "12345"}'
 })
 .then(({data}) => console.log('DATA\n', data))
 .catch(error => console.log(error));

--- a/src/apiReqs/apiReqsClient.js
+++ b/src/apiReqs/apiReqsClient.js
@@ -64,7 +64,7 @@ module.exports[getUser] = ({ user_id, full_dehydrate, headers, clientInfo }) => 
   return axios.get(url, { headers });
 };
 
-module.exports[getPlatformTransactions] = ({ page, per_page, clientInfo }) => {
+module.exports[getPlatformTransactions] = ({ page, per_page, filter, clientInfo }) => {
   const { host, headers } = clientInfo;
 
   return axios.get(
@@ -72,7 +72,8 @@ module.exports[getPlatformTransactions] = ({ page, per_page, clientInfo }) => {
       // STATIC ENDPOINT
       originalUrl: `${host}/trans`,
       page,
-      per_page
+      per_page,
+      filter
     }),
     { headers }
   );

--- a/src/apiReqs/apiReqsClient.js
+++ b/src/apiReqs/apiReqsClient.js
@@ -79,13 +79,14 @@ module.exports[getPlatformTransactions] = ({ page, per_page, filter, clientInfo 
   );
 };
 
-module.exports[getPlatformNodes] = ({ page, per_page, clientInfo }) => {
+module.exports[getPlatformNodes] = ({ page, per_page, filter, clientInfo }) => {
   const { host, headers } = clientInfo;
   const url = addQueryParams({
     // STATIC ENDPOINT
     originalUrl: `${host}/nodes`,
     page,
-    per_page
+    per_page,
+    filter
   });
 
   return axios.get(url, { headers });

--- a/src/apiReqs/apiReqsUser.js
+++ b/src/apiReqs/apiReqsUser.js
@@ -106,13 +106,14 @@ module.exports[getNode] = ({ node_id, full_dehydrate, force_refresh, userInfo })
   return axios.get(url, { headers });
 };
 
-module.exports[getUserTransactions] = ({ page, per_page, userInfo }) => {
+module.exports[getUserTransactions] = ({ page, per_page, filter, userInfo }) => {
   const { host, headers, id } = userInfo;
   const url = addQueryParams({
     // STATIC ENDPOINT
     originalUrl: `${host}/users/${id}/trans`,
     page,
-    per_page
+    per_page,
+    filter
   });
 
   return axios.get(url, { headers });
@@ -224,12 +225,13 @@ module.exports[getTransaction] = ({ node_id, trans_id, userInfo }) => {
   return axios.get(url, { headers });
 };
 
-module.exports[getAllNodeTransactions] = ({ node_id, trans_id, page, per_page, userInfo }) => {
+module.exports[getAllNodeTransactions] = ({ node_id, trans_id, page, per_page, filter, userInfo }) => {
   const { host, headers, id } = userInfo;
   const url = addQueryParams({
     originalUrl: `${host}/users/${id}/nodes/${node_id}/trans`,
     page,
-    per_page
+    per_page,
+    filter
   });
 
   return axios.get(url, { headers });

--- a/src/helpers/buildUrls.js
+++ b/src/helpers/buildUrls.js
@@ -6,6 +6,7 @@ module.exports.addQueryParams = ({
   query,
   page,
   per_page,
+  filter,
   show_refresh_tokens,
   full_dehydrate,
   force_refresh,
@@ -34,6 +35,9 @@ module.exports.addQueryParams = ({
   }
   if (per_page !== undefined) {
     params.push(`per_page=${per_page}`);
+  }
+  if (filter !== undefined) {
+    params.push(`filter=${filter}`);
   }
   if (show_refresh_tokens !== undefined) {
     params.push(`show_refresh_tokens=${show_refresh_tokens}`);

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -106,11 +106,12 @@ class Client {
 
   // GET ALL PLATFORM TRANSACTIONS
   getPlatformTransactions(queryParams = {}) {
-    const { page, per_page } = queryParams;
+    const { page, per_page, filter } = queryParams;
 
     return apiRequests.client[getPlatformTransactions]({
       page,
       per_page,
+      filter,
       clientInfo: this
     });
   }

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -118,11 +118,12 @@ class Client {
 
   // GET ALL PLATFORM NODES
   getPlatformNodes(queryParams = {}) {
-    const { page, per_page } = queryParams;
+    const { page, per_page, filter } = queryParams;
 
     return apiRequests.client[getPlatformNodes]({
       page,
       per_page,
+      filter,
       clientInfo: this
     });
   }

--- a/src/lib/User.js
+++ b/src/lib/User.js
@@ -187,11 +187,12 @@ class User {
 
   // GET ALL USER TRANSACTIONS
   getUserTransactions(queryParams = {}) {
-    const { page, per_page } = queryParams;
+    const { page, per_page, filter } = queryParams;
 
     return apiRequests.user[getUserTransactions]({
       page,
       per_page,
+      filter,
       userInfo: this
     });
   }
@@ -333,12 +334,13 @@ class User {
 
   // GET ALL NODE TRANSACTIONS
   getAllNodeTransactions(node_id, queryParams = {}) {
-    const { page, per_page } = queryParams;
+    const { page, per_page, filter } = queryParams;
 
     return apiRequests.user[getAllNodeTransactions]({
       node_id,
       page,
       per_page,
+      filter,
       userInfo: this
     });
   }


### PR DESCRIPTION
Some API endpoints support filter param. This param is very important to write optimal queries and fetch relevant results. SynapseNode was missing this param.