### PR TITLE
feat: Adding view and delete card shipment to Node wrapper [ENGRTF-1944]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsenode",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Node.js Library for SynapseFI API v3.1 Rest",
   "main": "dist/index.js",
   "files": [

--- a/samples.md
+++ b/samples.md
@@ -49,6 +49,9 @@
   * [Create Subnet](#create-subnet)
   * [Update Subnet](#update-subnet)
   * [Ship Card Subnet](#ship-card-subnet)
+  * [Get All Card Subnet Shipments](#get-all-card-subnet-shipments)
+  * [Get Card Subnet Shipment](#get-card-subnet-shipment)
+  * [Delete Card Subnet Shipment](#delete-card-subnet-shipment)
   * [Register New Fingerprint](#register-new-fingerprint)
 - [Idempotent Requests](#idempotent-requests)
 
@@ -927,6 +930,28 @@ user.shipCard('<NODE_ID>', '<SUBNET_ID>', {
 .then(({data}) => console.log('DATA\n', data))
 .catch(error => console.log(error));
 ```
+#### Get All Card Subnet Shipments
+```javascript
+user.getAllCardShipments('<NODE_ID>', '<SUBNET_ID>', {
+  per_page: 10,
+  page = 1
+})
+.then(({data}) => console.log('DATA\n', data))
+.catch(error => console.log(error));
+```
+#### Get Card Subnet Shipment
+```javascript
+user.getCardShipment('<NODE_ID>', '<SUBNET_ID>', '<SHIPMENT_ID>' )
+.then(({data}) => console.log('DATA\n', data))
+.catch(error => console.log(error));
+```
+#### Delete Card Subnet Shipment
+```javascript
+user.deleteCardShipment('<NODE_ID>', '<SUBNET_ID>', '<SHIPMENT_ID>')
+.then(({data}) => console.log('DATA\n', data))
+.catch(error => console.log(error));
+```
+
 #### Register New Fingerprint
 ##### Step 1
 ```javascript

--- a/src/apiReqs/apiReqsUser.js
+++ b/src/apiReqs/apiReqsUser.js
@@ -329,10 +329,24 @@ module.exports[getAllCardShipments] = ({ node_id, subnet_id, page, per_page, use
     page,
     per_page
   }) 
-  console.log(url)
   return axios.get(url, { headers });
 };
 
+module.exports[getCardShipment] = ({ node_id, subnet_id, shipment_id, userInfo}) => {
+  const { host, headers, id } = userInfo;
+  const url = addQueryParams({
+    originalUrl : `${host}/users/${id}/nodes/${node_id}/subnets/${subnet_id}/ship/${shipment_id}`
+  }) 
+  return axios.get(url, { headers });
+};
+
+module.exports[deleteCardShipment] = ({ node_id, subnet_id, shipment_id, userInfo}) => {
+  const { host, headers, id } = userInfo;
+  const url = addQueryParams({
+    originalUrl : `${host}/users/${id}/nodes/${node_id}/subnets/${subnet_id}/ship/${shipment_id}`
+  }) 
+  return axios.get(url, { headers });
+};
 
 module.exports[registerNewFingerprint] = ({ refresh_token, userInfo }) => {
   const { host, headers, id } = userInfo;

--- a/src/apiReqs/apiReqsUser.js
+++ b/src/apiReqs/apiReqsUser.js
@@ -37,6 +37,9 @@ const {
   supplyDevice2FA,
   verifyFingerprint2FA,
   createBatchTransactions,
+  getAllCardShipments,
+  getCardShipment,
+  deleteCardShipment,
 } = require('../constants/apiReqNames');
 
 const { addQueryParams, replacePathParams } = require('../helpers/buildUrls');
@@ -318,6 +321,18 @@ module.exports[shipCard] = ({ node_id, subnet_id, bodyParams, userInfo }) => {
 
   return axios.patch(url, bodyParams, { headers });
 };
+
+module.exports[getAllCardShipments] = ({ node_id, subnet_id, page, per_page, userInfo }) => {
+  const { host, headers, id } = userInfo;
+  const url = addQueryParams({
+    originalUrl : `${host}/users/${id}/nodes/${node_id}/subnets/${subnet_id}/ship`,
+    page,
+    per_page
+  }) 
+  console.log(url)
+  return axios.get(url, { headers });
+};
+
 
 module.exports[registerNewFingerprint] = ({ refresh_token, userInfo }) => {
   const { host, headers, id } = userInfo;

--- a/src/constants/apiReqNames.js
+++ b/src/constants/apiReqNames.js
@@ -54,5 +54,7 @@ module.exports = {
   getTradeMarketData: 'getTradeMarketData',
   verifyRoutingNumber: 'verifyRoutingNumber',
   createBatchTransactions: 'createBatchTransactions',
-  getAllCardShipments: 'getAllCardShipments'
+  getAllCardShipments: 'getAllCardShipments',
+  getCardShipment: 'getCardShipment',
+  deleteCardShipment: 'deleteCardShipment',
 };

--- a/src/constants/apiReqNames.js
+++ b/src/constants/apiReqNames.js
@@ -54,4 +54,5 @@ module.exports = {
   getTradeMarketData: 'getTradeMarketData',
   verifyRoutingNumber: 'verifyRoutingNumber',
   createBatchTransactions: 'createBatchTransactions',
+  getAllCardShipments: 'getAllCardShipments'
 };

--- a/src/lib/User.js
+++ b/src/lib/User.js
@@ -38,6 +38,8 @@ const {
   updateIpAddress,
   createBatchTransactions,
   getAllCardShipments,
+  getCardShipment,
+  deleteCardShipment
 } = require('../constants/apiReqNames');
 
 const apiRequests = require('../apiReqs/apiRequests');
@@ -462,8 +464,17 @@ class User {
     });
   }
 
-  // GET ALL CARD SHIPMENTS
-
+  /**
+   * GET ALL CARD SHIPMENTS
+   * @param {String} node_id required: id of node belonging to the subnet
+   * @param {String} subnet_id required: id of card subnet for the card shipments
+   * @param {Object} bodyParams optional: body of post request, can contain page and per_page keys indicating the amount of card shipments returned  
+   * 
+   * @returns Promise
+   * 
+   * 
+   * [Get Card Shipment Docs]{@link https://docs.synapsefi.com/api-references/shipments/view-all-subnet-shipments}
+   */
   getAllCardShipments(node_id, subnet_id, queryParams={}) {
     const { page, per_page } = queryParams 
     return apiRequests.user[getAllCardShipments]({
@@ -471,6 +482,46 @@ class User {
       subnet_id,
       page,
       per_page,
+      userInfo: this
+    })
+  }
+
+  /**
+   * GET A SINGLE CARD SHIPMENT
+   * @param {String} node_id required: id of node belonging to the subnet
+   * @param {String} subnet_id required: id of card subnet for the card shipments
+   * @param {Object} shipment_id requred: id of card shipment  
+   * 
+   * @returns Promise
+   * 
+   * 
+   * [Get Card Shipment Docs]{@link https://docs.synapsefi.com/api-references/shipments/view-shipment}
+   */
+  getCardShipment(node_id, subnet_id, shipment_id) {
+    return apiRequests.user[getCardShipment]({
+      node_id, 
+      subnet_id,
+      shipment_id,
+      userInfo: this
+    })
+  }
+
+  /**
+   * DELETE A SINGLE CARD SHIPMENT
+   * @param {String} node_id required: id of node belonging to the subnet
+   * @param {String} subnet_id required: id of card subnet for the card shipments
+   * @param {Object} shipment_id requred: id of card shipment  
+   * 
+   * @returns Promise
+   * 
+   * 
+   * [Get Card Shipment Docs]{@link https://docs.synapsefi.com/api-references/shipments/cancel-shipment}
+   */
+  deleteCardShipment(node_id, subnet_id, shipment_id) {
+    return apiRequests.user[deleteCardShipment]({
+      node_id, 
+      subnet_id,
+      shipment_id,
       userInfo: this
     })
   }

--- a/src/lib/User.js
+++ b/src/lib/User.js
@@ -468,7 +468,7 @@ class User {
    * GET ALL CARD SHIPMENTS
    * @param {String} node_id required: id of node belonging to the subnet
    * @param {String} subnet_id required: id of card subnet for the card shipments
-   * @param {Object} bodyParams optional: body of post request, can contain page and per_page keys indicating the amount of card shipments returned  
+   * @param {Object} queryParams optional: body of post request, can contain page and per_page keys indicating the amount of card shipments returned  
    * 
    * @returns Promise
    * 

--- a/src/lib/User.js
+++ b/src/lib/User.js
@@ -37,6 +37,7 @@ const {
   getUser,
   updateIpAddress,
   createBatchTransactions,
+  getAllCardShipments,
 } = require('../constants/apiReqNames');
 
 const apiRequests = require('../apiReqs/apiRequests');
@@ -459,6 +460,19 @@ class User {
       bodyParams,
       userInfo: this
     });
+  }
+
+  // GET ALL CARD SHIPMENTS
+
+  getAllCardShipments(node_id, subnet_id, queryParams={}) {
+    const { page, per_page } = queryParams 
+    return apiRequests.user[getAllCardShipments]({
+      node_id, 
+      subnet_id,
+      page,
+      per_page,
+      userInfo: this
+    })
   }
 
   // POST First call for registering new fingerprint


### PR DESCRIPTION
Adding the capability to view all subnet shipments, view single subnet shipment, and deleting subnet shipment to wrapper to account for the new API endpoints below:

- https://docs.synapsefi.com/api-references/shipments/view-all-subnet-shipments
- https://docs.synapsefi.com/api-references/shipments/view-shipment
- https://docs.synapsefi.com/api-references/shipments/cancel-shipment