### PR TITLE
ENGRTF-2635 update axios to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsenode",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "Node.js Library for SynapseFI API v3.1 Rest",
   "main": "dist/index.js",
   "files": [
@@ -23,7 +23,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.25.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.6",
@@ -42,11 +42,11 @@
     "randomatic": "^3.1.1"
   },
   "peerDependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.25.0",
     "lodash": "^4.17.10"
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.25.0",
     "dotenv": "^6.2.0"
   }
 }


### PR DESCRIPTION
[Jira Ticket](https://synapsefi.atlassian.net/browse/ENGRTF-2635)

## Description
- Axios 0.18.0 has Forgery(SSRF) Medium severityRegular Expression Denial of Service(ReDOS) High Severity exploits.

## Updates 
- update Axios version to latest 0.25.0

## Notes
- compared breaking changes for all version leading up to 0.25.0
- [change log](https://github.com/axios/axios/blob/master/CHANGELOG.md)
- there are no known issues for breaking changes
- npm run test performs the same for axios 0.18.0 and 0.25.0

- there are a lot of unit tests not running well, they should be fixed in future commits